### PR TITLE
Add option to only mirror last N versions of a package

### DIFF
--- a/pyshop.sample.ini
+++ b/pyshop.sample.ini
@@ -53,6 +53,7 @@ pyshop.upload.rewrite_filename = 0
 
 pyshop.mirror.cache.ttl = 24
 pyshop.mirror.sanitize = 0
+pyshop.mirror.last_n_versions = 0
 pyshop.mirror.sanitize.regex = ^[0-9]+(\.[0-9]+)*([a-f][0-9]*)?$
 
 # build_egg will create a binary format of the mirrored version

--- a/pyshop/views/simple.py
+++ b/pyshop/views/simple.py
@@ -9,6 +9,7 @@ import re
 import logging
 import os.path
 import unicodedata
+import heapq
 from datetime import datetime, timedelta
 
 from sqlalchemy.sql.expression import func
@@ -370,6 +371,11 @@ class Show(View):
                 log.info('No new version to mirror')
                 log.debug('pypi versions: %s', pypi_versions)
                 log.debug('mirrored versions: %s', pkg.versions)
+
+            last_n_versions = int(settings.get('pyshop.mirror.last_n_versions', 0))
+            if last_n_versions > 0:
+                pkg_versions = heapq.nlargest(last_n_versions, pkg_versions)
+
             for version in pkg_versions:
                 log.info('Mirroring version %s', version)
                 release_data = api.release_data(package_name, version)


### PR DESCRIPTION
When mirroring new packages on pyshop, every version is downloaded and mirrored. With popular projects like `requests`, there are a large number of versions and this can often lead to pip timeouts while waiting for pyshop to download all the versions.

This pull request provides an option to only take the last `N` versions when mirroring public packages and reign the number of downloads in below the pip timeout.  

Leaving the option `pyshop.mirror.last_n_versions` at the default `0` will permit pyshop to continue downloading all versions.